### PR TITLE
Use env base URL for API calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,5 @@ DB_PASS=cidade_pass
 SPRING_PORT=5011
 
 # Frontend
+# Base URL para as chamadas da aplicação frontend
 VITE_API_BASE_URL=http://localhost:5011

--- a/frontend/src/components/WebhookTestButton.tsx
+++ b/frontend/src/components/WebhookTestButton.tsx
@@ -4,7 +4,7 @@ const WebhookTestButton: React.FC = () => {
   const enviarParaN8N = async () => {
     try {
       const response = await fetch(
-        "fetch('http://localhost:5678/webhook/inserir-usuario', {\n",
+        `${import.meta.env.VITE_API_BASE_URL}/webhook/inserir-usuario`,
         {
           method: "POST",
           headers: {

--- a/frontend/src/components/recepcao/IdentificacaoMunicipe.tsx
+++ b/frontend/src/components/recepcao/IdentificacaoMunicipe.tsx
@@ -47,7 +47,7 @@ export const IdentificacaoMunicipe: React.FC<IdentificacaoProps> = ({
   const atualizarDadosContato = async (usuarioId: string) => {
     try {
       const response = await fetch(
-        `http://localhost:5000/api/usuarios/${usuarioId}/contato`,
+        `${import.meta.env.VITE_API_BASE_URL}/api/usuarios/${usuarioId}/contato`,
         {
           method: "PATCH",
           headers: {
@@ -90,7 +90,7 @@ export const IdentificacaoMunicipe: React.FC<IdentificacaoProps> = ({
   const buscarUsuarioPorBiometria = async (templateId: string) => {
     try {
       const response = await fetch(
-        `http://localhost:5000/api/biometria/ler/${templateId}`,
+        `${import.meta.env.VITE_API_BASE_URL}/api/biometria/ler/${templateId}`,
       );
       const data = await response.json();
 
@@ -110,7 +110,7 @@ export const IdentificacaoMunicipe: React.FC<IdentificacaoProps> = ({
         // 🔎 Verifica agendamento ativo
         try {
           const agendamentoResp = await fetch(
-            `http://localhost:5000/api/agendamentos/ativo/${data.usuario.id}`,
+            `${import.meta.env.VITE_API_BASE_URL}/api/agendamentos/ativo/${data.usuario.id}`,
           );
           const agendamentoData = await agendamentoResp.json();
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,7 +3,7 @@
 import axios from 'axios';
 
 const apiService = axios.create({
-  baseURL: 'http://localhost:5011/api',
+  baseURL: `${import.meta.env.VITE_API_BASE_URL}/api`,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -2,20 +2,11 @@
 
 import axios from 'axios';
 
-const apiService = axios.create({
-    baseURL: 'http://localhost:5011/api', // Padronizado com /api
-    headers: {
-        'Content-Type': 'application/json',
-    },
-});// src/services/apiService.ts
-
-import axios from 'axios';
-
-const apiService = axios.create({
-    baseURL: 'http://localhost:5011/api', // Padronizado com /api
-    headers: {
-        'Content-Type': 'application/json',
-    },
+export const apiService = axios.create({
+  baseURL: `${import.meta.env.VITE_API_BASE_URL}/api`,
+  headers: {
+    'Content-Type': 'application/json',
+  },
 });
 
 // Interceptor para adicionar token JWT automaticamente


### PR DESCRIPTION
## Summary
- rely on `VITE_API_BASE_URL` for Axios setup
- update munícipe identification API calls
- fix WebhookTestButton fetch URL
- document the API URL variable in `.env.example`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e02b595dc83258ba2c814edfe7013