### PR TITLE
Add medication stock table and API service

### DIFF
--- a/frontend/src/components/farmacia/EstoqueMedicamentos.tsx
+++ b/frontend/src/components/farmacia/EstoqueMedicamentos.tsx
@@ -1,24 +1,105 @@
-import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import React, { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Plus, Minus } from "lucide-react";
+import { estoqueMedicamentoService, MedicamentoEstoque } from "@/services/estoqueMedicamentoService";
+import apiService from "@/services/apiService";
+import { UnidadeSaude } from "@/types/Paciente";
 
-// ✅ CORRIGIDO: Define a interface para as props do componente
 interface EstoqueMedicamentosProps {
   unidadeId: string;
 }
 
-// ✅ CORRIGIDO: Usa a interface de props para tipar o componente
 export const EstoqueMedicamentos: React.FC<EstoqueMedicamentosProps> = ({ unidadeId }) => {
-  // Aqui você pode adicionar a lógica para buscar e exibir os medicamentos
-  // com base no unidadeId recebido.
+  const [unidades, setUnidades] = useState<UnidadeSaude[]>([]);
+  const [selecionada, setSelecionada] = useState<string>(unidadeId);
+  const [medicamentos, setMedicamentos] = useState<MedicamentoEstoque[]>([]);
+
+  useEffect(() => {
+    apiService
+      .get("/unidades")
+      .then((res) => setUnidades(res.data.data))
+      .catch((err) => console.error("Falha ao carregar unidades", err));
+  }, []);
+
+  useEffect(() => {
+    if (!selecionada) return;
+    estoqueMedicamentoService
+      .listar(selecionada)
+      .then(setMedicamentos)
+      .catch(() => setMedicamentos([]));
+  }, [selecionada]);
+
+  const ajustar = (id: number, delta: number) => {
+    const item = medicamentos.find((m) => m.id === id);
+    if (!item) return;
+    const quantidade = item.quantidade + delta;
+    setMedicamentos((prev) =>
+      prev.map((m) => (m.id === id ? { ...m, quantidade } : m)),
+    );
+    estoqueMedicamentoService.ajustarQuantidade(id, quantidade).catch(() => {});
+  };
+
   return (
-      <Card className="mt-2">
-        <CardHeader>
-          <CardTitle>Controle de Medicamentos</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p>Exibindo estoque de medicamentos para a unidade: {unidadeId}</p>
-          {/* Futuramente, aqui entrará a lista de medicamentos */}
-        </CardContent>
-      </Card>
+    <Card className="mt-2">
+      <CardHeader>
+        <CardTitle>Controle de Medicamentos</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="mb-4 flex items-center gap-2">
+          <Select value={selecionada} onValueChange={setSelecionada}>
+            <SelectTrigger className="w-64">
+              <SelectValue placeholder="Selecione a unidade" />
+            </SelectTrigger>
+            <SelectContent>
+              {unidades.map((u) => (
+                <SelectItem key={u.id} value={String(u.id)}>{u.nome}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Nome</TableHead>
+              <TableHead>Lote</TableHead>
+              <TableHead>Validade</TableHead>
+              <TableHead className="text-right">Quantidade</TableHead>
+              <TableHead className="text-center">Ações</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {medicamentos.map((m) => (
+              <TableRow key={m.id}>
+                <TableCell>{m.nome}</TableCell>
+                <TableCell>{m.lote}</TableCell>
+                <TableCell>{m.validade}</TableCell>
+                <TableCell className="text-right">{m.quantidade}</TableCell>
+                <TableCell className="text-center space-x-2">
+                  <Button size="icon" variant="outline" onClick={() => ajustar(m.id, 1)}>
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                  <Button size="icon" variant="outline" onClick={() => ajustar(m.id, -1)}>
+                    <Minus className="h-4 w-4" />
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        {medicamentos.length === 0 && (
+          <p className="pt-4 text-sm text-muted-foreground">Nenhum medicamento encontrado.</p>
+        )}
+      </CardContent>
+    </Card>
   );
 };
+

--- a/frontend/src/services/estoqueMedicamentoService.ts
+++ b/frontend/src/services/estoqueMedicamentoService.ts
@@ -1,0 +1,33 @@
+import { apiService } from "@/services/apiService";
+
+export interface MedicamentoEstoque {
+  id: number;
+  nome: string;
+  lote: string;
+  validade: string;
+  quantidade: number;
+}
+
+export class EstoqueMedicamentoService {
+  async listar(unidadeId?: string): Promise<MedicamentoEstoque[]> {
+    try {
+      const url = unidadeId ? `/medicamentos?unidadeId=${unidadeId}` : "/medicamentos";
+      const res = await apiService.get<{ data: MedicamentoEstoque[] }>(url);
+      return res.data.data;
+    } catch (error) {
+      console.error("Erro ao buscar estoque de medicamentos", error);
+      return [];
+    }
+  }
+
+  async ajustarQuantidade(id: number, quantidade: number): Promise<void> {
+    try {
+      await apiService.patch(`/medicamentos/${id}`, { quantidade });
+    } catch (error) {
+      console.error("Erro ao ajustar quantidade de medicamento", error);
+    }
+  }
+}
+
+export const estoqueMedicamentoService = new EstoqueMedicamentoService();
+

--- a/frontend/src/services/tests/estoqueMedicamentoService.test.ts
+++ b/frontend/src/services/tests/estoqueMedicamentoService.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { estoqueMedicamentoService } from "../estoqueMedicamentoService";
+import { apiService } from "../apiService";
+
+vi.mock("../apiService", () => ({
+  apiService: {
+    get: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+describe("estoqueMedicamentoService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deve listar medicamentos via API", async () => {
+    const mockResponse = {
+      data: { data: [{ id: 1, nome: "Teste", lote: "L1", validade: "2025-01-01", quantidade: 5 }] },
+    };
+    vi.mocked(apiService.get).mockResolvedValue(mockResponse as any);
+
+    const result = await estoqueMedicamentoService.listar("1");
+
+    expect(result).toHaveLength(1);
+    expect(apiService.get).toHaveBeenCalledWith("/medicamentos?unidadeId=1");
+  });
+
+  it("deve retornar lista vazia em caso de erro", async () => {
+    vi.mocked(apiService.get).mockRejectedValue(new Error("erro"));
+
+    const result = await estoqueMedicamentoService.listar();
+
+    expect(result).toEqual([]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- fetch medication stock from API with new service
- show medication table with quantity adjustment and unit filter
- add tests for the service

## Testing
- `npm test --prefix frontend` *(fails: cannot find module @rollup/rollup-linux-x64-gnu)*
- `mvn -q -f backend/pom.xml test` *(fails: mvn: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb0034c908325925ac09450c1419b